### PR TITLE
add sensor service to libjustshoot

### DIFF
--- a/POST_sGSI_Patches/Vendor/Blobs HAX/POST-sGSI_2/META-INF/com/google/android/update-binary
+++ b/POST_sGSI_Patches/Vendor/Blobs HAX/POST-sGSI_2/META-INF/com/google/android/update-binary
@@ -164,3 +164,8 @@ if [ -e "/vendor/lib64/libsensorndkbridge.so" ]; then
 fi
 
 #Cam
+
+#Motorola camera
+if [ -e "/vendor/lib/libjustshoot.so" ]; then
+    sed -i "s/android.frameworks.sensorservice@1.0.so/Wndroid.frameworks.sensorservice@1.0.so/" /vendor/lib/libjustshoot.so
+fi


### PR DESCRIPTION
missing symbols in the camera on some motorola devices like Addison