### PR TITLE
README.md: Add java 8 dependency

### DIFF
--- a/systemimgmaker/README.md
+++ b/systemimgmaker/README.md
@@ -19,7 +19,7 @@ cd ~/AndroidWorkspace/Capire-Le-Treble/Extra
 sudo ./sGSI-ify.sh ~/AndroidWorkspace/system/system 2147483648 ~/AndroidWorkspace/sGSI_A.img
 <wait until you see "Press any key to continue">
 ```
-### and open another terminal tab (use python 2.x):
+### and open another terminal tab (use python 2.x and Java 8):
 ```
 cd ~/AndroidWorkspace/ROM_resigner
 sudo python resign.py ~/AndroidWorkspace/Capire-Le-Treble/Extra/tmp/system ~/AndroidWorkspace/android_build/target/product/security
@@ -34,7 +34,7 @@ cd ~/AndroidWorkspace/Capire-Le-Treble/Extra
 sudo ./sGSI-ify_ab.sh ~/AndroidWorkspace/system 2147483648 ~/AndroidWorkspace/sGSI_AB.img
 <wait until you see "Press any key to continue">
 ```
-### and open another terminal tab (use python 2.x):
+### and open another terminal tab (use python 2.x and Java 8):
 ```
 cd ~/AndroidWorkspace/ROM_resigner
 sudo python resign.py ~/AndroidWorkspace/Capire-Le-Treble/Extra/tmp/system/system ~/AndroidWorkspace/android_build/target/product/security


### PR DESCRIPTION
change 1 - 
the system /bin/sh might not be able to process the "[" in the if logic(as in the case of Ubuntu 18.04). This also explains change 4, 5 and 7
change 2 - 
there is no /system/system in A type. Similarly /system/system should be the case in AB explaining change 6
Change 3 -
signapk.jar uses deprecated libs (sun.misc.*) which were deprecated Java 9 onwards. Thus singapk only works with Java 8 and below.